### PR TITLE
Ignore the crawlers folder when validating

### DIFF
--- a/scripts/bash_tests.sh
+++ b/scripts/bash_tests.sh
@@ -7,7 +7,7 @@
 testFilesWithPrint() {
     # count the number of print statements in the file
     # The number of print statements should be 0
-    FILES_WITH_PRINT=$(grep -Rwl --exclude-dir={static,scripts,__pycache__,venv} "print" ./*)
+    FILES_WITH_PRINT=$(grep -Rwl --exclude-dir={static,scripts,__pycache__,venv,crawlers} "print" ./*)
     FILES_COUNT=$(echo "$FILES_WITH_PRINT" | grep -v -e '^$' | tr ' ' '\n' | wc -l)
 
     if [ $FILES_COUNT != 0 ]; then


### PR DESCRIPTION
## PR description
Added the `crawlers` folder to be ignored when validating if the python scripts contain the print statement or not.

## Solution description
Added the `crawlers` folder as an ignore folder inside the bash script.

## Covered unit test cases
No.

## Is this PR associated with an issue
No.
